### PR TITLE
보유 매물 브로커 위임 기능 구현

### DIFF
--- a/src/main/java/com/realestate/app/domain/broker_profile/BrokerProfile.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/BrokerProfile.java
@@ -41,6 +41,14 @@ public class BrokerProfile {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt; // 수정일
 
+    @Column(name = "total_deals", nullable = false)
+    @Builder.Default
+    private Integer totalDeals = 0;
+
+    @Column(name = "pending_deals", nullable = false)
+    @Builder.Default
+    private Integer pendingDeals = 0;
+
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/realestate/app/domain/broker_profile/BrokerProfileRepository.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/BrokerProfileRepository.java
@@ -1,10 +1,46 @@
 package com.realestate.app.domain.broker_profile;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface BrokerProfileRepository extends JpaRepository<BrokerProfile, Long> {
+
+    @EntityGraph(attributePaths = "user") // ← user까지 한 번에 로딩
     Optional<BrokerProfile> findByUserId(Long userId);
-    boolean existsByLicenseNumber(String licenseNumber);
+
+    /** 브로커 검색 (username/agencyName/licenseNumber) + 활성 유저 + broker 역할 */
+    @EntityGraph(attributePaths = "user") // ← 페이지 조회 시에도 user 미리 로딩
+    @Query(
+            value = """
+            select bp
+            from BrokerProfile bp
+            join bp.user u
+            where u.isActive = true
+              and u.roleId = 'broker'
+              and (
+                    :q is null or :q = '' or
+                    lower(u.username) like lower(concat('%', :q, '%')) or
+                    lower(bp.agencyName) like lower(concat('%', :q, '%')) or
+                    lower(bp.licenseNumber) like lower(concat('%', :q, '%'))
+                  )
+            """,
+            countQuery = """
+            select count(bp)
+            from BrokerProfile bp
+            join bp.user u
+            where u.isActive = true
+              and u.roleId = 'broker'
+              and (
+                    :q is null or :q = '' or
+                    lower(u.username) like lower(concat('%', :q, '%')) or
+                    lower(bp.agencyName) like lower(concat('%', :q, '%')) or
+                    lower(bp.licenseNumber) like lower(concat('%', :q, '%'))
+                  )
+            """
+    )
+    Page<BrokerProfile> searchBrokers(@Param("q") String q, Pageable pageable);
 }

--- a/src/main/java/com/realestate/app/domain/broker_profile/api/BrokerQueryController.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/api/BrokerQueryController.java
@@ -1,0 +1,46 @@
+package com.realestate.app.domain.broker_profile.api;
+
+import com.realestate.app.domain.broker_profile.app.BrokerQueryService;
+import com.realestate.app.domain.broker_profile.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/brokers")
+public class BrokerQueryController {
+
+    private final BrokerQueryService service;
+
+    /** 브로커 목록(검색/페이지/정렬) */
+    @GetMapping
+    public PageResponse<BrokerListItemResponse> list(
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false, defaultValue = "totalDeals,desc") String sort
+    ) {
+        // sort 파싱: "field,dir"
+        Sort s = parseSort(sort);
+        return service.search(q, page, size, s);
+    }
+
+    /** 브로커 상세 (userId = broker_profiles.user_id) */
+    @GetMapping("/{userId}")
+    public BrokerDetailResponse detail(@PathVariable Long userId) {
+        return service.get(userId);
+    }
+
+    private Sort parseSort(String sort) {
+        try {
+            if (sort == null || sort.isBlank()) return Sort.by(Sort.Order.desc("totalDeals"));
+            String[] parts = sort.split(",");
+            String prop = parts[0].trim();
+            String dir  = parts.length > 1 ? parts[1].trim().toLowerCase() : "asc";
+            return "desc".equals(dir) ? Sort.by(Sort.Order.desc(prop)) : Sort.by(Sort.Order.asc(prop));
+        } catch (Exception e) {
+            return Sort.by(Sort.Order.desc("totalDeals"));
+        }
+    }
+}

--- a/src/main/java/com/realestate/app/domain/broker_profile/app/BrokerQueryService.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/app/BrokerQueryService.java
@@ -1,0 +1,56 @@
+package com.realestate.app.domain.broker_profile.app;
+
+import com.realestate.app.domain.broker_profile.BrokerProfile;
+import com.realestate.app.domain.broker_profile.BrokerProfileRepository;
+import com.realestate.app.domain.broker_profile.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class BrokerQueryService {
+
+    private final BrokerProfileRepository repo;
+
+    @Transactional(readOnly = true)
+    public PageResponse<BrokerListItemResponse> search(String q, int page, int size, Sort sort) {
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<BrokerProfile> p = repo.searchBrokers(q, pageable);
+        var list = p.map(bp -> new BrokerListItemResponse(
+                bp.getUserId(),
+                bp.getUser().getUsername(),    // 트랜잭션 + EntityGraph로 안전
+                bp.getAgencyName(),
+                bp.getLicenseNumber(),
+                bp.getProfileImageUrl(),
+                bp.getTotalDeals(),
+                bp.getPendingDeals()
+        )).getContent();
+        return new PageResponse<>(list, p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
+    }
+
+    @Transactional(readOnly = true)
+    public BrokerDetailResponse get(Long userId) {
+        BrokerProfile bp = repo.findByUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "broker not found"));
+
+        var u = bp.getUser(); // 트랜잭션 + EntityGraph로 안전
+        if (u.getIsActive() == null || !u.getIsActive() || !"broker".equals(u.getRoleId())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "broker not found");
+        }
+        return new BrokerDetailResponse(
+                bp.getUserId(),
+                u.getUsername(),
+                bp.getAgencyName(),
+                bp.getLicenseNumber(),
+                bp.getProfileImageUrl(),
+                bp.getIntro(),
+                u.getPhoneNumber(),
+                bp.getTotalDeals(),
+                bp.getPendingDeals()
+        );
+    }
+}

--- a/src/main/java/com/realestate/app/domain/broker_profile/dto/BrokerDetailResponse.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/dto/BrokerDetailResponse.java
@@ -1,0 +1,13 @@
+package com.realestate.app.domain.broker_profile.dto;
+
+public record BrokerDetailResponse(
+        Long userId,
+        String username,
+        String agencyName,
+        String licenseNumber,
+        String profileImageUrl,
+        String intro,
+        String phoneNumber,
+        Integer totalDeals,
+        Integer pendingDeals
+) {}

--- a/src/main/java/com/realestate/app/domain/broker_profile/dto/BrokerListItemResponse.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/dto/BrokerListItemResponse.java
@@ -1,0 +1,11 @@
+package com.realestate.app.domain.broker_profile.dto;
+
+public record BrokerListItemResponse(
+        Long userId,
+        String username,
+        String agencyName,
+        String licenseNumber,
+        String profileImageUrl,
+        Integer totalDeals,
+        Integer pendingDeals
+) {}

--- a/src/main/java/com/realestate/app/domain/broker_profile/dto/PageResponse.java
+++ b/src/main/java/com/realestate/app/domain/broker_profile/dto/PageResponse.java
@@ -1,0 +1,10 @@
+package com.realestate.app.domain.broker_profile.dto;
+
+import java.util.List;
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {}

--- a/src/main/java/com/realestate/app/domain/delegation/BrokerDelegationRequest.java
+++ b/src/main/java/com/realestate/app/domain/delegation/BrokerDelegationRequest.java
@@ -1,0 +1,62 @@
+package com.realestate.app.domain.delegation;
+
+import com.realestate.app.domain.broker_profile.BrokerProfile;
+import com.realestate.app.domain.property.table.Property;
+import com.realestate.app.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "broker_delegation_requests")
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class BrokerDelegationRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 요청자(소유자) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    /** 대상 매물 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "property_id", nullable = false)
+    private Property property;
+
+    /** 대상 중개인 (broker_profiles.user_id FK) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "broker_user_id", referencedColumnName = "user_id", nullable = false)
+    private BrokerProfile broker;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16, nullable = false)
+    private Status status; // PENDING/APPROVED/REJECTED/CANCELED
+
+    @Column(name = "reject_reason", columnDefinition = "TEXT")
+    private String rejectReason;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.status == null) this.status = Status.PENDING;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public enum Status { PENDING, APPROVED, REJECTED, CANCELED }
+}

--- a/src/main/java/com/realestate/app/domain/delegation/api/DelegationCheckController.java
+++ b/src/main/java/com/realestate/app/domain/delegation/api/DelegationCheckController.java
@@ -1,0 +1,48 @@
+package com.realestate.app.domain.delegation.api;
+
+import com.realestate.app.domain.delegation.BrokerDelegationRequest;
+import com.realestate.app.domain.delegation.BrokerDelegationRequest.Status;
+import com.realestate.app.domain.delegation.repository.BrokerDelegationRequestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/properties")
+public class DelegationCheckController {
+
+    private final BrokerDelegationRequestRepository repo;
+
+    /** 특정 매물에 PENDING 위임요청 존재 여부 */
+    @GetMapping("/{propertyId}/delegations/pending")
+    public Map<String, Object> hasPending(@PathVariable Long propertyId) {
+        return repo.findFirstByProperty_IdAndStatus(propertyId, Status.PENDING)
+                .map(r -> Map.<String, Object>of(
+                        "hasPending", true,
+                        "requestId", r.getId(),
+                        "brokerUserId", r.getBroker().getUserId(),
+                        "createdAt", r.getCreatedAt()
+                ))
+                .orElseGet(() -> Map.<String, Object>of("hasPending", false));
+    }
+
+    /** (옵션) 특정 상태로 존재 여부 확인: /api/properties/{id}/delegations/check?status=PENDING */
+    @GetMapping("/{propertyId}/delegations/check")
+    public Map<String, Object> hasByStatus(@PathVariable Long propertyId,
+                                           @RequestParam(defaultValue = "PENDING") Status status) {
+        return repo.findFirstByProperty_IdAndStatus(propertyId, status)
+                .map(r -> Map.<String, Object>of(
+                        "exists", true,
+                        "status", r.getStatus().name(),
+                        "requestId", r.getId(),
+                        "brokerUserId", r.getBroker().getUserId(),
+                        "createdAt", r.getCreatedAt()
+                ))
+                .orElseGet(() -> Map.<String, Object>of(
+                        "exists", false,
+                        "status", status.name()
+                ));
+    }
+}

--- a/src/main/java/com/realestate/app/domain/delegation/api/DelegationController.java
+++ b/src/main/java/com/realestate/app/domain/delegation/api/DelegationController.java
@@ -1,0 +1,79 @@
+package com.realestate.app.domain.delegation.api;
+
+import com.realestate.app.domain.delegation.BrokerDelegationRequest.Status;
+import com.realestate.app.domain.delegation.app.DelegationService;
+import com.realestate.app.domain.delegation.dto.CreateDelegationRequest;
+import com.realestate.app.domain.delegation.dto.DecisionRequest;
+import com.realestate.app.domain.delegation.dto.DelegationResponse;
+import com.realestate.app.global.security.CurrentUserIdResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class DelegationController {
+
+    private final DelegationService service;
+    private final CurrentUserIdResolver currentUserIdResolver;
+
+    /** 소유자: 위임요청 생성 */
+    @PostMapping("/properties/{propertyId}/delegations")
+    public DelegationResponse create(Authentication auth,
+                                     @PathVariable Long propertyId,
+                                     @RequestBody CreateDelegationRequest body) {
+        Long ownerUserId = currentUserIdResolver.requireUserId(auth);
+        return service.create(ownerUserId, propertyId, body.brokerUserId());
+    }
+
+    /** 브로커: 받은 요청 목록 */
+    @GetMapping("/delegations/incoming")
+    public List<DelegationResponse> incoming(Authentication auth,
+                                             @RequestParam(defaultValue = "PENDING") Status status) {
+        Long brokerUserId = currentUserIdResolver.requireUserId(auth);
+        return service.incomingForBroker(brokerUserId, status);
+    }
+
+    /** 소유자: 내가 만든 요청 목록 */
+    @GetMapping("/delegations/mine")
+    public List<DelegationResponse> mine(Authentication auth) {
+        Long ownerUserId = currentUserIdResolver.requireUserId(auth);
+        return service.mineForOwner(ownerUserId);
+    }
+
+    /** 브로커: 승인 */
+    @PostMapping("/delegations/{id}/approve")
+    public DelegationResponse approve(Authentication auth, @PathVariable Long id) {
+        Long brokerUserId = currentUserIdResolver.requireUserId(auth);
+        return service.approve(brokerUserId, id);
+    }
+
+    /** 브로커: 거절 */
+    @PostMapping("/delegations/{id}/reject")
+    public DelegationResponse reject(Authentication auth, @PathVariable Long id,
+                                     @RequestBody(required = false) DecisionRequest body) {
+        Long brokerUserId = currentUserIdResolver.requireUserId(auth);
+        String reason = body == null ? null : body.reason();
+        return service.reject(brokerUserId, id, reason);
+    }
+
+    /** 소유자: 취소 */
+    @PostMapping("/delegations/{id}/cancel")
+    public DelegationResponse cancel(Authentication auth, @PathVariable Long id) {
+        Long ownerUserId = currentUserIdResolver.requireUserId(auth);
+        return service.cancel(ownerUserId, id);
+    }
+
+    /** 소유자: 목록에서 요청 제거 */
+    @DeleteMapping("/delegations/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(Authentication auth, @PathVariable Long id) {
+        Long ownerUserId = currentUserIdResolver.requireUserId(auth);
+        service.deleteOwn(ownerUserId, id);
+    }
+}

--- a/src/main/java/com/realestate/app/domain/delegation/app/DelegationService.java
+++ b/src/main/java/com/realestate/app/domain/delegation/app/DelegationService.java
@@ -1,0 +1,132 @@
+package com.realestate.app.domain.delegation.app;
+
+import com.realestate.app.domain.broker_profile.BrokerProfile;
+import com.realestate.app.domain.broker_profile.BrokerProfileRepository;
+import com.realestate.app.domain.delegation.BrokerDelegationRequest;
+import com.realestate.app.domain.delegation.BrokerDelegationRequest.Status;
+import com.realestate.app.domain.delegation.dto.DelegationResponse;
+import com.realestate.app.domain.delegation.repository.BrokerDelegationRequestRepository;
+import com.realestate.app.domain.property.table.Property;
+import com.realestate.app.domain.property.table.Property.ListingType;
+import com.realestate.app.domain.property.repository.PropertyRepository;
+import com.realestate.app.domain.user.entity.User;
+import com.realestate.app.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DelegationService {
+
+    private final BrokerDelegationRequestRepository reqRepo;
+    private final PropertyRepository propertyRepo;
+    private final UserRepository userRepo;
+    private final BrokerProfileRepository brokerProfileRepo;
+
+    @Transactional
+    public DelegationResponse create(Long ownerUserId, Long propertyId, Long brokerUserId) {
+        Property property = propertyRepo.findById(propertyId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "property not found"));
+        User owner = userRepo.findById(ownerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "owner not found"));
+
+        if (property.getOwner() == null || !property.getOwner().getId().equals(owner.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "you are not the owner of this property");
+        }
+
+        // 단일 PENDING 보장
+        if (reqRepo.existsByProperty_IdAndStatus(propertyId, Status.PENDING)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "already has a pending delegation");
+        }
+
+        BrokerProfile broker = brokerProfileRepo.findByUserId(brokerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "broker profile not found"));
+
+        BrokerDelegationRequest req = BrokerDelegationRequest.builder()
+                .owner(owner)
+                .property(property)
+                .broker(broker)
+                .status(Status.PENDING)
+                .build();
+
+        reqRepo.save(req);
+        return toDto(req);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DelegationResponse> incomingForBroker(Long brokerUserId, Status status) {
+        return reqRepo.findAllByBroker_UserIdAndStatus(brokerUserId, status).stream()
+                .map(this::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<DelegationResponse> mineForOwner(Long ownerUserId) {
+        return reqRepo.findAllByOwner_Id(ownerUserId).stream()
+                .map(this::toDto).toList();
+    }
+
+    @Transactional
+    public DelegationResponse approve(Long brokerUserId, Long requestId) {
+        BrokerDelegationRequest req = reqRepo.findByIdAndBroker_UserId(requestId, brokerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "request not found"));
+        if (req.getStatus() != Status.PENDING) throw new ResponseStatusException(HttpStatus.CONFLICT, "not pending");
+
+        // 승인: 매물에 중개인 지정 + listingType=BROKER
+        Property p = req.getProperty();
+        p.setBroker(req.getBroker());
+        p.setListingType(ListingType.BROKER);
+
+        req.setStatus(Status.APPROVED);
+        return toDto(req);
+    }
+
+    @Transactional
+    public DelegationResponse reject(Long brokerUserId, Long requestId, String reason) {
+        BrokerDelegationRequest req = reqRepo.findByIdAndBroker_UserId(requestId, brokerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "request not found"));
+        if (req.getStatus() != Status.PENDING) throw new ResponseStatusException(HttpStatus.CONFLICT, "not pending");
+
+        req.setStatus(Status.REJECTED);
+        req.setRejectReason(reason);
+        return toDto(req);
+    }
+
+    @Transactional
+    public DelegationResponse cancel(Long ownerUserId, Long requestId) {
+        BrokerDelegationRequest req = reqRepo.findByIdAndOwner_Id(requestId, ownerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "request not found"));
+        if (req.getStatus() != Status.PENDING) throw new ResponseStatusException(HttpStatus.CONFLICT, "not pending");
+
+        req.setStatus(Status.CANCELED);
+        return toDto(req);
+    }
+
+    @Transactional
+    public void deleteOwn(Long ownerUserId, Long requestId) {
+        var req = reqRepo.findByIdAndOwner_Id(requestId, ownerUserId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "request not found"));
+
+        if (req.getStatus() == BrokerDelegationRequest.Status.APPROVED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "approved request cannot be deleted");
+        }
+
+        // 트리거가 PENDING 삭제 시 pending_deals를 알아서 -1 해줌
+        reqRepo.delete(req);
+    }
+
+    private DelegationResponse toDto(BrokerDelegationRequest r) {
+        return new DelegationResponse(
+                r.getId(),
+                r.getProperty().getId(),
+                r.getOwner().getId(),
+                r.getBroker().getUserId(),
+                r.getStatus(),
+                r.getRejectReason()
+        );
+    }
+}

--- a/src/main/java/com/realestate/app/domain/delegation/dto/CreateDelegationRequest.java
+++ b/src/main/java/com/realestate/app/domain/delegation/dto/CreateDelegationRequest.java
@@ -1,0 +1,3 @@
+package com.realestate.app.domain.delegation.dto;
+
+public record CreateDelegationRequest(Long brokerUserId) {}

--- a/src/main/java/com/realestate/app/domain/delegation/dto/DecisionRequest.java
+++ b/src/main/java/com/realestate/app/domain/delegation/dto/DecisionRequest.java
@@ -1,0 +1,3 @@
+package com.realestate.app.domain.delegation.dto;
+
+public record DecisionRequest(String reason) {}

--- a/src/main/java/com/realestate/app/domain/delegation/dto/DelegationResponse.java
+++ b/src/main/java/com/realestate/app/domain/delegation/dto/DelegationResponse.java
@@ -1,0 +1,12 @@
+package com.realestate.app.domain.delegation.dto;
+
+import com.realestate.app.domain.delegation.BrokerDelegationRequest.Status;
+
+public record DelegationResponse(
+        Long id,
+        Long propertyId,
+        Long ownerId,
+        Long brokerUserId,
+        Status status,
+        String rejectReason
+) {}

--- a/src/main/java/com/realestate/app/domain/delegation/repository/BrokerDelegationRequestRepository.java
+++ b/src/main/java/com/realestate/app/domain/delegation/repository/BrokerDelegationRequestRepository.java
@@ -1,0 +1,21 @@
+package com.realestate.app.domain.delegation.repository;
+
+import com.realestate.app.domain.delegation.BrokerDelegationRequest;
+import com.realestate.app.domain.delegation.BrokerDelegationRequest.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BrokerDelegationRequestRepository extends JpaRepository<BrokerDelegationRequest, Long> {
+
+    boolean existsByProperty_IdAndStatus(Long propertyId, Status status);
+    Optional<BrokerDelegationRequest> findFirstByProperty_IdAndStatus(Long propertyId, Status status);
+
+    Optional<BrokerDelegationRequest> findByIdAndBroker_UserId(Long id, Long brokerUserId);
+    Optional<BrokerDelegationRequest> findByIdAndOwner_Id(Long id, Long ownerUserId);
+
+    List<BrokerDelegationRequest> findAllByBroker_UserIdAndStatus(Long brokerUserId, Status status);
+    List<BrokerDelegationRequest> findAllByOwner_Id(Long ownerUserId);
+}
+

--- a/src/main/java/com/realestate/app/global/security/CurrentUserIdResolver.java
+++ b/src/main/java/com/realestate/app/global/security/CurrentUserIdResolver.java
@@ -1,0 +1,40 @@
+package com.realestate.app.global.security;
+
+import com.realestate.app.domain.user.entity.User;
+import com.realestate.app.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserIdResolver {
+
+    private final UserRepository userRepository;
+
+    public Long requireUserId(Authentication auth) {
+        if (auth == null || auth.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "no authentication");
+        }
+        String name = auth.getName();
+
+        // name이 숫자면 그대로 사용
+        if (isNumeric(name)) {
+            try { return Long.parseLong(name); }
+            catch (NumberFormatException ignored) { /* fallthrough to email lookup */ }
+        }
+        // 숫자가 아니면 이메일로 유저 조회해서 id 반환
+        User u = userRepository.findByEmail(name)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "user not found by email"));
+        return u.getId();
+    }
+
+    private boolean isNumeric(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (!Character.isDigit(s.charAt(i))) return false;
+        }
+        return !s.isEmpty();
+    }
+}

--- a/src/main/resources/db/migration/V6__create_broker_delegation_requests.sql
+++ b/src/main/resources/db/migration/V6__create_broker_delegation_requests.sql
@@ -1,0 +1,28 @@
+-- V6__create_broker_delegation_requests.sql
+
+CREATE TABLE broker_delegation_requests (
+    id               BIGSERIAL PRIMARY KEY,
+    owner_id         BIGINT NOT NULL,
+    property_id      BIGINT NOT NULL,
+    broker_user_id   BIGINT NOT NULL,
+    status           VARCHAR(16) NOT NULL,
+    reject_reason    TEXT,
+    created_at       TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMP NOT NULL DEFAULT now(),
+
+    CONSTRAINT fk_deleg_owner    FOREIGN KEY (owner_id)        REFERENCES users (id),
+    CONSTRAINT fk_deleg_property FOREIGN KEY (property_id)     REFERENCES properties (id),
+    CONSTRAINT fk_deleg_broker   FOREIGN KEY (broker_user_id)  REFERENCES broker_profiles (user_id),
+
+    CONSTRAINT ck_deleg_status CHECK (status IN ('PENDING','APPROVED','REJECTED','CANCELED'))
+);
+
+-- 조회 최적화 인덱스
+CREATE INDEX idx_deleg_broker_status ON broker_delegation_requests (broker_user_id, status);
+CREATE INDEX idx_deleg_owner         ON broker_delegation_requests (owner_id);
+CREATE INDEX idx_deleg_property      ON broker_delegation_requests (property_id);
+
+-- 단일 요청 보장: 동일 매물(property_id)에 PENDING 상태는 하나만 허용
+CREATE UNIQUE INDEX uq_deleg_property_pending
+    ON broker_delegation_requests (property_id)
+    WHERE status = 'PENDING';

--- a/src/main/resources/db/migration/V7__add_deal_counts_to_broker_profiles.sql
+++ b/src/main/resources/db/migration/V7__add_deal_counts_to_broker_profiles.sql
@@ -1,0 +1,113 @@
+-- V7__add_deal_counts_to_broker_profiles.sql
+-- 1) 컬럼 추가
+ALTER TABLE broker_profiles
+  ADD COLUMN total_deals   INT NOT NULL DEFAULT 0,
+  ADD COLUMN pending_deals INT NOT NULL DEFAULT 0;
+
+-- 2) 기존 데이터 백필(backfill)
+-- pending_deals: 현재 PENDING 상태의 위임요청 수
+UPDATE broker_profiles bp
+SET pending_deals = COALESCE(src.cnt, 0)
+FROM (
+  SELECT r.broker_user_id AS user_id, COUNT(*) AS cnt
+  FROM broker_delegation_requests r
+  WHERE r.status = 'PENDING'
+  GROUP BY r.broker_user_id
+) src
+WHERE bp.user_id = src.user_id;
+
+-- total_deals: 실제 거래완료(SOLD)된 브로커 매물 수 (listing_type = 'BROKER')
+UPDATE broker_profiles bp
+SET total_deals = COALESCE(src.cnt, 0)
+FROM (
+  SELECT p.broker_id AS user_id, COUNT(*) AS cnt
+  FROM properties p
+  WHERE p.listing_type = 'BROKER'
+    AND p.status = 'SOLD'
+    AND p.broker_id IS NOT NULL
+  GROUP BY p.broker_id
+) src
+WHERE bp.user_id = src.user_id;
+
+-- 3) pending_deals 자동 유지 트리거
+CREATE OR REPLACE FUNCTION trg_bdr_pending_deals()
+RETURNS trigger AS $$
+BEGIN
+  -- INSERT: 새로 PENDING이면 +1
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status = 'PENDING' THEN
+      UPDATE broker_profiles
+         SET pending_deals = pending_deals + 1
+       WHERE user_id = NEW.broker_user_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- UPDATE: PENDING -> 비PENDING 이면 -1 / 비PENDING -> PENDING 이면 +1
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.status = 'PENDING' AND NEW.status <> 'PENDING' THEN
+      UPDATE broker_profiles
+         SET pending_deals = GREATEST(pending_deals - 1, 0)
+       WHERE user_id = NEW.broker_user_id;
+    ELSIF OLD.status <> 'PENDING' AND NEW.status = 'PENDING' THEN
+      UPDATE broker_profiles
+         SET pending_deals = pending_deals + 1
+       WHERE user_id = NEW.broker_user_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- DELETE: PENDING 레코드 삭제 시 -1
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status = 'PENDING' THEN
+      UPDATE broker_profiles
+         SET pending_deals = GREATEST(pending_deals - 1, 0)
+       WHERE user_id = OLD.broker_user_id;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS bdr_pending_deals_trg ON broker_delegation_requests;
+CREATE TRIGGER bdr_pending_deals_trg
+AFTER INSERT OR UPDATE OR DELETE ON broker_delegation_requests
+FOR EACH ROW EXECUTE FUNCTION trg_bdr_pending_deals();
+
+-- 4) total_deals 자동 유지 트리거
+-- properties.status 가 SOLD 로 바뀔 때 +1, SOLD 해제 시 -1
+CREATE OR REPLACE FUNCTION trg_properties_total_deals()
+RETURNS trigger AS $$
+DECLARE
+  broker_user_id BIGINT;
+BEGIN
+  -- SOLD 진입
+  IF (OLD.status IS DISTINCT FROM 'SOLD') AND (NEW.status = 'SOLD') THEN
+    IF NEW.broker_id IS NOT NULL AND NEW.listing_type = 'BROKER' THEN
+      broker_user_id := NEW.broker_id; -- FK -> broker_profiles.user_id
+      UPDATE broker_profiles
+         SET total_deals = total_deals + 1
+       WHERE user_id = broker_user_id;
+    END IF;
+  END IF;
+
+  -- SOLD 해제(롤백)
+  IF (OLD.status = 'SOLD') AND (NEW.status IS DISTINCT FROM 'SOLD') THEN
+    IF OLD.broker_id IS NOT NULL AND OLD.listing_type = 'BROKER' THEN
+      broker_user_id := OLD.broker_id;
+      UPDATE broker_profiles
+         SET total_deals = GREATEST(total_deals - 1, 0)
+       WHERE user_id = broker_user_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS properties_total_deals_trg ON properties;
+CREATE TRIGGER properties_total_deals_trg
+AFTER UPDATE OF status ON properties
+FOR EACH ROW EXECUTE FUNCTION trg_properties_total_deals();


### PR DESCRIPTION
1. 소유자가 자기 매물 브로커한테 위임 요청
2. 브로커가 요청에 대해 승인
3. 브로커가 요청에 대해 거부
4. 소유자가 요청 취소
5. 소유자가 보낸 요청 조회
6. 브로커가 자기한테 온 요청 조회
7. 소유자가 자기가 보낸 요청 목록에서 요청 삭제(승인된건 삭제불가) - 삭제 안하면 취소하든 승인되든 거부되든 디비에 다 저장돼있음
8. 브로커 프로필에 거래중 건수, 거래완료 건수 추가